### PR TITLE
Removed MinGW downgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,8 @@ up to date. Then in the same mingw-64 shell, run:
                         git subversion mercurial \
                         mingw-w64-i686-cmake mingw-w64-x86_64-cmake
 
-This will install all the tools needed for building and will take a while. Once complete, we have to downgrade a couple
-of packages due to a bug in the current MinGW libraries. In the same shell, run:
-
-    pacman -U /var/cache/pacman/pkg/mingw-w64-x86_64-crt-git-5.0.0.4745.d2384c2-1-any.pkg.tar.xz
-    pacman -U /var/cache/pacman/pkg/mingw-w64-x86_64-headers-git-5.0.0.4747.0f8f626-1-any.pkg.tar.xz
-    pacman -U /var/cache/pacman/pkg/mingw-w64-x86_64-winpthreads-git-5.0.0.4741.2c8939a-1-any.pkg.tar.xz \
-              /var/cache/pacman/pkg/mingw-w64-x86_64-libwinpthread-git-5.0.0.4741.2c8939a-1-any.pkg.tar.xz
-
-At least these were the cached package names on my install, they may be different on others. Once complete, MinGW is now
-setup to build the dependencies.
+This will install all the tools needed for building and will take a while. Once complete, MinGW is now setup to build 
+the dependencies.
 
 ### Executing the build
 


### PR DESCRIPTION
It is fixed in MinGW version 6.0.0.5136 and they should update to that if following your tutorial.

It's worth noting that I actually got the error by downgrading.
```
C:\msys64\mingw64\lib\go\pkg\tool\windows_amd64\link.exe: running gcc failed: exit status 1
E:\tmp\go-link-631259851\000005.o: In function `_cgo_preinit_init':
C:\repo\mingw-w64-go\src\go-1.10.1\src\runtime\cgo/gcc_libinit_windows.c:28: undefined reference to `__imp___acrt_iob_func'
E:\tmp\go-link-631259851\000005.o: In function `x_cgo_sys_thread_create':
C:\repo\mingw-w64-go\src\go-1.10.1\src\runtime\cgo/gcc_libinit_windows.c:58: undefined reference to `__imp___acrt_iob_func'
E:\tmp\go-link-631259851\000005.o: In function `x_cgo_notify_runtime_init_done':
C:\repo\mingw-w64-go\src\go-1.10.1\src\runtime\cgo/gcc_libinit_windows.c:99: undefined reference to `__imp___acrt_iob_func'
E:\tmp\go-link-631259851\000006.o: In function `x_cgo_thread_start':
C:\repo\mingw-w64-go\src\go-1.10.1\src\runtime\cgo/gcc_util.c:18: undefined reference to `__imp___acrt_iob_func'
E:\tmp\go-link-631259851\000007.o: In function `_cgo_sys_thread_start':
C:\repo\mingw-w64-go\src\go-1.10.1\src\runtime\cgo/gcc_windows_amd64.c:34: undefined reference to `__imp___acrt_iob_func'
```
When I used the updated packages it started compiling correctly.

`go version go1.10.1 windows/amd64`