### PR TITLE
build.go: strip the tor binary

### DIFF
--- a/build.go
+++ b/build.go
@@ -148,10 +148,10 @@ func build(folder string) error {
 				return fmt.Errorf("Unable to make symlink: %v", err)
 			}
 		}
-		var env []string
+		var env = []string{"LDFLAGS=-s"}
 		var torConf []string
 		if runtime.GOOS == "windows" {
-			env = []string{"LIBS=-lcrypt32"}
+			env = append(env, "LIBS=-lcrypt32")
 		}
 		torConf = []string{"sh", "./configure", "--prefix=" + pwd + "/dist",
 			"--disable-gcc-hardening", "--disable-system-torrc", "--disable-asciidoc",


### PR DESCRIPTION
this reduces the binary to only 5.9Mb (on Linux)

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>