### PR TITLE
Disable usage of zstd lib, this fixes #23

### DIFF
--- a/build.go
+++ b/build.go
@@ -167,6 +167,9 @@ func build(folder string) error {
 		if runtime.GOOS != "darwin" {
 			torConf = append(torConf, "--enable-static-tor")
 		}
+		if runtime.GOOS == "windows" {
+			torConf = append(torConf, "--disable-zstd")
+		}
 		return runCmds(folder, env, [][]string{
 			{"sh", "-l", "./autogen.sh"},
 			torConf,


### PR DESCRIPTION
This fixes the build for Windows, see https://ci.appveyor.com/project/lc/tor-static
This might not be necessary in newer versions of Tor