### PR TITLE
openssl: don't build docs

### DIFF
--- a/build.go
+++ b/build.go
@@ -115,7 +115,7 @@ func build(folder string) error {
 			{"sh", "./config", "--prefix=" + prefix, "--openssldir=" + prefix, "no-shared", "no-dso", "no-zlib"},
 			{"make", "depend"},
 			{"make", numJobs},
-			{"make", "install"},
+			{"make", "install_sw"},
 		}
 		if runtime.GOOS == "windows" {
 			cmds[0] = append(cmds[0], "mingw64")


### PR DESCRIPTION
[more information](https://github.com/openssl/openssl/issues/8170)

cuts down build time by approximately a lot